### PR TITLE
Fix misnamed abort/signal vars

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -209,15 +209,15 @@ request:
 
 <div class=example>
 ```js
-let signal = new AbortController();
+const abort = new AbortController();
 
 setTimeout(() => {
   // abort after two minutes
-  signal.abort();
+  abort.abort();
 }, 2 * 60 * 1000);
   
 let {code, type} = await navigator.credentials.get({
-  abort: signal,
+  signal: abort.signal,
   otp: {
     transport: ["sms"]
   }


### PR DESCRIPTION
The spec suggested passing the wrong variable. [`CredentialRequestOptions`](https://w3c.github.io/webappsec-credential-management/#credentialrequestoptions-dictionary) specifies that you can pass an instance of `AbortSignal`, which is provided on the instantiated `AbortController`.