### PR TITLE
Correct for Bikeshed 5.0.3

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8,7 +8,7 @@ ED: http://wicg.github.io/WebOTP
 Repository: WICG/WebOTP
 Editor: Sam Goto, Google Inc. https://google.com, goto@google.com
 Favicon: logo-otp.png
-Markup Shorthands: markdown yes, css no, biblio yes
+Markup Shorthands: markdown yes, css no, biblio yes, macros-in-autolinks yes
 Text Macro: FALSE <code>false</code>
 Text Macro: RP Relying Party
 Text Macro: RPS Relying Parties


### PR DESCRIPTION
Using macros inside of autolinks previously worked only accidentally; I made it work *explicitly* in Bikeshed 5.0. I've since walked back that decision, and put it behind a pref in 5.0.3.